### PR TITLE
Support the `cwd` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ The default export is a recma plugin.
 
 ### Options
 
-- `name` (`string`, default: `'filepath'`) — The name to export the file path as.
 - `absolute` (`boolean`, default: `false`) — If true, use an absolute path. By default a relative
   path is used.
+- `cwd` (`string`) The current working directory to use when generating a relative file path.
+- `name` (`string`, default: `'filepath'`) — The name to export the file path as.
 
 ## Compatibility
 

--- a/test.js
+++ b/test.js
@@ -67,6 +67,36 @@ test('absolute path', () => {
   assert.equal(String(result), 'export const filepath = "/home/user/example.js";\n')
 })
 
+test('cwd (absolute)', () => {
+  const result = recma().use(recmaExportFilepath, { cwd: '/home/user/docs/' }).processSync({
+    cwd: '/home/user',
+    path: '/home/user/docs/example.md',
+    value: ''
+  })
+
+  assert.equal(String(result), 'export const filepath = "example.md";\n')
+})
+
+test('cwd (relative)', () => {
+  const result = recma().use(recmaExportFilepath, { cwd: 'docs' }).processSync({
+    cwd: '/home/user',
+    path: '/home/user/docs/example.md',
+    value: ''
+  })
+
+  assert.equal(String(result), 'export const filepath = "example.md";\n')
+})
+
+test('cwd (relative with parent dir)', () => {
+  const result = recma().use(recmaExportFilepath, { cwd: '..' }).processSync({
+    cwd: '/home/user',
+    path: '/home/user/docs/example.md',
+    value: ''
+  })
+
+  assert.equal(String(result), 'export const filepath = "user/docs/example.md";\n')
+})
+
 test('insert as first statement', () => {
   const result = recma().use(recmaExportFilepath).processSync({
     cwd: '/home/user',


### PR DESCRIPTION
This feature add `cwd` option, which allows users to specify a different value than `process.cwd()`.

For example, your Markdown docs are located at `docs/` directory, but you execute Vite/Webpack from project root `./`. Without `cwd` option, you get:

```js
export const filepath = 'docs/foo/bar.md';
```

With `cwd: 'docs'`, you get:

```js
export const filepath = 'foo/bar.md'
```

The same feature are supported by a wide range of popular Node.js tools, like `fast-glob`, `chokidar`.